### PR TITLE
Enable access to CMV12K SPI registers

### DIFF
--- a/applets/cmv12k/spi_test.py
+++ b/applets/cmv12k/spi_test.py
@@ -3,8 +3,6 @@
 from nmigen import *
 from naps import *
 
-class Co: pass
-
 class Top(Elaboratable):
     def __init__(self):
         self.spi_clks = StatusSignal(32)
@@ -22,18 +20,8 @@ class Top(Elaboratable):
         m.d.comb += sensor.reset.eq(~self.sensor_reset_n)
 
         spi_pads = platform.request("sensor_spi")
-        p = Co()
-        p.clk = spi_pads.clk
-        p.copi = spi_pads.copi
-        p.cipo = spi_pads.cipo
-        pcs = Co()
-        pcs.o = Signal()
-        m.d.comb += spi_pads.cs.eq(~pcs.o)
-        p.cs = pcs
-
         m.d.sync += self.actual_cs.eq(spi_pads.cs)
-
-        m.submodules.spi = BitbangSPI(p)
+        m.submodules.spi = BitbangSPI(spi_pads)
 
         last_clk = Signal()
         m.d.sync += last_clk.eq(spi_pads.clk)

--- a/applets/cmv12k/spi_test.py
+++ b/applets/cmv12k/spi_test.py
@@ -1,0 +1,49 @@
+# set up SPI connection to CMV12k control pins
+
+from nmigen import *
+from naps import *
+
+class Co: pass
+
+class Top(Elaboratable):
+    def __init__(self):
+        self.spi_clks = StatusSignal(32)
+        self.actual_cs = StatusSignal(1)
+        self.sensor_reset_n = ControlSignal(name='sensor_reset', reset=1)
+
+    def elaborate(self, platform: BetaPlatform):
+        m = Module()
+
+        platform.ps7.fck_domain(requested_frequency=100e6)
+
+        sensor = platform.request("sensor")
+        platform.ps7.fck_domain(500e6, "sensor_clk")
+        m.d.comb += sensor.lvds_clk.eq(ClockSignal("sensor_clk"))
+        m.d.comb += sensor.reset.eq(~self.sensor_reset_n)
+
+        spi_pads = platform.request("sensor_spi")
+        p = Co()
+        p.clk = spi_pads.clk
+        p.copi = spi_pads.copi
+        p.cipo = spi_pads.cipo
+        pcs = Co()
+        pcs.o = Signal()
+        m.d.comb += spi_pads.cs.eq(pcs.o)
+        p.cs = pcs
+
+        m.d.sync += self.actual_cs.eq(spi_pads.cs)
+
+        m.submodules.spi = BitbangSPI(p)
+
+        last_clk = Signal()
+        m.d.sync += last_clk.eq(spi_pads.clk)
+        with m.If(~last_clk & spi_pads.clk):
+            m.d.sync += self.spi_clks.eq(self.spi_clks + 1)
+
+        clocking_debug = m.submodules.clocking_debug = ClockingDebug("sync")
+
+        return m
+
+
+if __name__ == "__main__":
+    cli(Top, runs_on=(BetaPlatform, ), possible_socs=(ZynqSocPlatform, ))

--- a/applets/cmv12k/spi_test.py
+++ b/applets/cmv12k/spi_test.py
@@ -17,7 +17,7 @@ class Top(Elaboratable):
         platform.ps7.fck_domain(requested_frequency=100e6)
 
         sensor = platform.request("sensor")
-        platform.ps7.fck_domain(500e6, "sensor_clk")
+        platform.ps7.fck_domain(250e6, "sensor_clk")
         m.d.comb += sensor.lvds_clk.eq(ClockSignal("sensor_clk"))
         m.d.comb += sensor.reset.eq(~self.sensor_reset_n)
 
@@ -28,7 +28,7 @@ class Top(Elaboratable):
         p.cipo = spi_pads.cipo
         pcs = Co()
         pcs.o = Signal()
-        m.d.comb += spi_pads.cs.eq(pcs.o)
+        m.d.comb += spi_pads.cs.eq(~pcs.o)
         p.cs = pcs
 
         m.d.sync += self.actual_cs.eq(spi_pads.cs)

--- a/applets/cmv12k/spi_test.py
+++ b/applets/cmv12k/spi_test.py
@@ -5,7 +5,7 @@ from naps import *
 
 class Top(Elaboratable):
     def __init__(self):
-        self.sensor_reset_n = ControlSignal(name='sensor_reset', reset=1)
+        self.sensor_reset = ControlSignal()
 
     def elaborate(self, platform: BetaPlatform):
         m = Module()
@@ -15,7 +15,7 @@ class Top(Elaboratable):
         sensor = platform.request("sensor")
         platform.ps7.fck_domain(250e6, "sensor_clk")
         m.d.comb += sensor.lvds_clk.eq(ClockSignal("sensor_clk"))
-        m.d.comb += sensor.reset.eq(~self.sensor_reset_n)
+        m.d.comb += sensor.reset.eq(self.sensor_reset)
 
         spi_pads = platform.request("sensor_spi")
         m.submodules.spi = BitbangSPI(spi_pads)

--- a/applets/cmv12k/spi_test.py
+++ b/applets/cmv12k/spi_test.py
@@ -5,8 +5,6 @@ from naps import *
 
 class Top(Elaboratable):
     def __init__(self):
-        self.spi_clks = StatusSignal(32)
-        self.actual_cs = StatusSignal(1)
         self.sensor_reset_n = ControlSignal(name='sensor_reset', reset=1)
 
     def elaborate(self, platform: BetaPlatform):
@@ -20,15 +18,7 @@ class Top(Elaboratable):
         m.d.comb += sensor.reset.eq(~self.sensor_reset_n)
 
         spi_pads = platform.request("sensor_spi")
-        m.d.sync += self.actual_cs.eq(spi_pads.cs)
         m.submodules.spi = BitbangSPI(spi_pads)
-
-        last_clk = Signal()
-        m.d.sync += last_clk.eq(spi_pads.clk)
-        with m.If(~last_clk & spi_pads.clk):
-            m.d.sync += self.spi_clks.eq(self.spi_clks + 1)
-
-        clocking_debug = m.submodules.clocking_debug = ClockingDebug("sync")
 
         return m
 

--- a/naps/cores/peripherals/__init__.py
+++ b/naps/cores/peripherals/__init__.py
@@ -1,4 +1,5 @@
 from .bitbang_i2c import *
+from .bitbang_spi import *
 from .csr_bank import *
 from .drp_bridge import *
 from .mmio_gpio import *

--- a/naps/cores/peripherals/bitbang_spi.py
+++ b/naps/cores/peripherals/bitbang_spi.py
@@ -35,7 +35,7 @@ class BitbangSPI(Elaboratable):
                     reg = <0>;      
                     #address-cells = <1>;
                     #size-cells = <0>;
-                    spi-max-frequency = <1000000>;
+                    spi-max-frequency = <30000000>;
                 };
             };
         """

--- a/naps/cores/peripherals/bitbang_spi.py
+++ b/naps/cores/peripherals/bitbang_spi.py
@@ -1,0 +1,44 @@
+from nmigen import *
+
+from naps.cores.peripherals.mmio_gpio import MmioGpio
+from naps.soc.devicetree_overlay import devicetree_overlay
+from naps.soc.soc_platform import SocPlatform
+
+__all__ = ["BitbangSPI"]
+
+
+class BitbangSPI(Elaboratable):
+    def __init__(self, pins, name_suffix=""):
+        self.devicetree_name = "bitbang_spi" + name_suffix
+        self.mmio_gpio = MmioGpio(pads=(pins.clk, pins.copi, pins.cipo, pins.cs), name_suffix="_" + self.devicetree_name)
+
+    def elaborate(self, platform: SocPlatform):
+        m = Module()
+        m.submodules.mmio_gpio = self.mmio_gpio
+
+        overlay_content = """
+            %overlay_name%: spi@0 {
+                compatible = "spi-gpio";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                ranges;
+
+                sck-gpios = <&%mmio_gpio% 0 0>;
+                mosi-gpios = <&%mmio_gpio% 1 0>;
+                miso-gpios = <&%mmio_gpio% 2 0>;
+                cs-gpios = <&%mmio_gpio% 3 0>;
+                num_chipselects = <1>;
+                status = "ok";
+
+                spidev1 {
+                    compatible = "spidev";
+                    reg = <0>;      
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                    spi-max-frequency = <1000000>;
+                };
+            };
+        """
+        devicetree_overlay(platform, self.devicetree_name, overlay_content, {"mmio_gpio": self.mmio_gpio.devicetree_name})
+
+        return m

--- a/naps/cores/peripherals/bitbang_spi.py
+++ b/naps/cores/peripherals/bitbang_spi.py
@@ -18,13 +18,10 @@ class BitbangSPI(Elaboratable):
         # for some reason, despite CS being specified as active high in the
         # device tree, linux and/or the python spidev module treat it as active
         # low. thus we invert CS here to make the pin active high as defined
-        pins = Record.like(self.pins)
-        m.d.comb += self.pins.clk.eq(pins.clk)
-        m.d.comb += self.pins.copi.eq(pins.copi)
-        m.d.comb += pins.cipo.eq(self.pins.cipo)
-        m.d.comb += self.pins.cs.eq(~pins.cs)
+        ncs = Record.like(self.pins.cs)
+        m.d.comb += self.pins.cs.eq(~ncs)
 
-        self.mmio_gpio = MmioGpio(pads=(pins.clk, pins.copi, pins.cipo, pins.cs), name_suffix="_" + self.devicetree_name)
+        self.mmio_gpio = MmioGpio(pads=(self.pins.clk, self.pins.copi, self.pins.cipo, ncs), name_suffix="_" + self.devicetree_name)
         m.submodules.mmio_gpio = self.mmio_gpio
 
         overlay_content = """

--- a/naps/cores/peripherals/mmio_gpio.py
+++ b/naps/cores/peripherals/mmio_gpio.py
@@ -36,8 +36,8 @@ class MmioGpio(Elaboratable):
         devicetree_overlay(platform, self.devicetree_name, overlay_content, {"set": self.set, "dat": self.dat, "dirout": self.dirout})
 
         for i, pad in enumerate(self._pads):
-            m.d.comb += self.dat[i].eq(pad.i)
-            m.d.comb += pad.oe.eq(self.dirout[i])
-            m.d.comb += pad.o.eq(self.set[i])
+            if hasattr(pad, "i"): m.d.comb += self.dat[i].eq(pad.i)
+            if hasattr(pad, "oe"): m.d.comb += pad.oe.eq(self.dirout[i])
+            if hasattr(pad, "o"): m.d.comb += pad.o.eq(self.set[i])
 
         return m

--- a/naps/cores/peripherals/mmio_gpio.py
+++ b/naps/cores/peripherals/mmio_gpio.py
@@ -36,8 +36,11 @@ class MmioGpio(Elaboratable):
         devicetree_overlay(platform, self.devicetree_name, overlay_content, {"set": self.set, "dat": self.dat, "dirout": self.dirout})
 
         for i, pad in enumerate(self._pads):
-            if hasattr(pad, "i"): m.d.comb += self.dat[i].eq(pad.i)
-            if hasattr(pad, "oe"): m.d.comb += pad.oe.eq(self.dirout[i])
-            if hasattr(pad, "o"): m.d.comb += pad.o.eq(self.set[i])
+            if hasattr(pad, "i"):
+                m.d.comb += self.dat[i].eq(pad.i)
+            if hasattr(pad, "oe"):
+                m.d.comb += pad.oe.eq(self.dirout[i])
+            if hasattr(pad, "o"):
+                m.d.comb += pad.o.eq(self.set[i])
 
         return m

--- a/naps/platform/beta_platform.py
+++ b/naps/platform/beta_platform.py
@@ -73,7 +73,7 @@ class BetaPlatform(MicroZedZ020Platform):
                      Subsignal("lvds_clk", DiffPairs("81", "83", dir='o', conn=("JX1", 0)), Attrs(IOSTANDARD="LVDS_25", SLEW="SLOW")),
                      *lvds_lanes,
                      Subsignal("lvds_ctrl", DiffPairs("82", "84", dir='i', conn=("JX2", 0)), Attrs(IOSTANDARD="LVDS_25", DIFF_TERM="TRUE", IBUF_LOW_PWR="TRUE")),
-                     Subsignal("lvds_outclk", DiffPairsN("48", "50", dir='i', conn=("JX2", 0)), Attrs(IOSTANDARD="LVDS_25", DIFF_TERM="TRUE", IBUF_LOW_PWR="TRUE")),
+                     Subsignal("lvds_outclk", DiffPairsN("48", "50", dir='i', conn=("JX1", 0)), Attrs(IOSTANDARD="LVDS_25", DIFF_TERM="TRUE", IBUF_LOW_PWR="TRUE")),
                      ),
             Resource("sensor_spi", 0,
                      Subsignal("cs", Pins("24", dir='o', conn=("JX1", 0)), Attrs(IOSTANDARD="LVCMOS25")),

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ setup(
 
             'scipy',  # only needed for vifp calculation
             'matplotlib',
+
+            'spidev',
         ],
         'doc': [
             'sphinx<4',


### PR DESCRIPTION
This PR adds all the necessary infrastructure to be able to read and write CMV12K SPI registers through a Linux SPI device and the nMigen gateware.