### PR TITLE
RFC: Print timing summary at end of execution

### DIFF
--- a/naps/util/timer.py
+++ b/naps/util/timer.py
@@ -1,8 +1,21 @@
+import atexit
 from time import time
 
 
 current_task = None
 current_start = None
+
+task_timings = []
+
+def print_task_timing(current_task, elapsed):
+    print(f"🕑 {current_task} took {elapsed:.2f} s")
+
+@atexit.register
+def print_summary_at_end():
+    print(f"### timing summary")
+    for task_timing in task_timings:
+        print_task_timing(*task_timing)
+
 
 
 def start_task(name):
@@ -17,6 +30,7 @@ def end_task():
     global current_task, current_start
     if current_task is not None:
         assert current_start is not None
-        print(f"🕑 {current_task} took {(time() - current_start):.2f} s")
+        task_timings.append((current_task, time() - current_start))
+        print_task_timing(*task_timings[-1])
     current_task = None
     current_start = None


### PR DESCRIPTION
So one does not have to scroll back trough pages of irrelevant stuff to find the timing summary.