### PR TITLE
Add applet to receive test pattern from CMV12K sensor

### DIFF
--- a/applets/cmv12k/pattern_test.py
+++ b/applets/cmv12k/pattern_test.py
@@ -1,0 +1,172 @@
+# set up and demonstrate capturing the test pattern of CMV12k
+
+# DEMO PROCEDURE:
+# 1. build the fatbitstream with `python3 applets/cmv12k/pattern_test.py -b`
+# 2. copy the resulting build/pattern_test_*/pattern_test.zip file to the Beta
+# 3. log into the Beta and get root access with e.g. `sudo su`
+# 4. power up the sensor with `axiom_power_init.sh && axiom_power_on.sh`
+# 5. load the fatbitstream with `./pattern_test.zip --run`
+# 6. run `pattern = design.capture_pattern()` function at the prompt
+
+from nmigen import *
+from nmigen.lib.cdc import PulseSynchronizer
+from naps import *
+
+class Stats(Elaboratable):
+    def __init__(self):
+        self.data_valid_count = StatusSignal(32)
+        self.line_valid_count = StatusSignal(32)
+        self.frame_valid_count = StatusSignal(32)
+        self.ctrl_value = StatusSignal(12)
+        self.reset = PulseReg(1)
+
+        self.ctrl_lane = Signal(12)
+        self.ctrl_valid = Signal()
+
+        self.frame_trigger = Signal()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules += self.reset
+
+        reset_sync = m.submodules.reset_sync = PulseSynchronizer(platform.csr_domain, "sync")
+        m.d.comb += reset_sync.i.eq(self.reset.pulse)
+
+        with m.If(reset_sync.o):
+            m.d.sync += [
+                self.data_valid_count.eq(0),
+                self.line_valid_count.eq(0),
+                self.frame_valid_count.eq(0),
+            ]
+
+        with m.If(self.ctrl_valid):
+            m.d.sync += self.ctrl_value.eq(self.ctrl_lane)
+
+        with m.If(self.ctrl_lane[0] & self.ctrl_valid):
+            m.d.sync += self.data_valid_count.eq(self.data_valid_count + 1)
+        with m.If(self.ctrl_lane[1] & self.ctrl_valid):
+            m.d.sync += self.line_valid_count.eq(self.line_valid_count + 1)
+        with m.If(self.ctrl_lane[2] & self.ctrl_valid):
+            m.d.sync += self.frame_valid_count.eq(self.frame_valid_count + 1)
+
+        frame_valid = Signal()
+        last_frame_valid = Signal()
+        m.d.sync += [
+            frame_valid.eq(self.ctrl_lane[2] & self.ctrl_valid),
+            last_frame_valid.eq(frame_valid),
+        ]
+        m.d.comb += self.frame_trigger.eq(~last_frame_valid & frame_valid)
+
+        return m
+
+class Top(Elaboratable):
+    def __init__(self):
+        self.sensor_reset = ControlSignal()
+        self.frame_req = PulseReg(1)
+
+    def elaborate(self, platform: BetaPlatform):
+        m = Module()
+
+        m.submodules += self.frame_req
+
+        platform.ps7.fck_domain(requested_frequency=100e6)
+
+        sensor = platform.request("sensor")
+        platform.ps7.fck_domain(250e6, "sensor_clk")
+        m.d.comb += sensor.lvds_clk.eq(ClockSignal("sensor_clk"))
+        m.d.comb += sensor.reset.eq(self.sensor_reset)
+
+        m.d.comb += [
+            sensor.frame_req.eq(self.frame_req.pulse),
+            sensor.t_exp1.eq(0),
+            sensor.t_exp2.eq(0),
+        ]
+
+        m.submodules.sensor_spi = Cmv12kSpi(platform.request("sensor_spi"))
+        sensor_rx = m.submodules.sensor_rx = Cmv12kRx(sensor)
+        stats = m.submodules.stats = DomainRenamer("cmv12k_hword")(Stats())
+        trig_sync = m.submodules.trig_sync = PulseSynchronizer(platform.csr_domain, "cmv12k_hword")
+
+        m.d.comb += [
+            stats.ctrl_lane.eq(sensor_rx.phy.output[-1]),
+            stats.ctrl_valid.eq(sensor_rx.phy.output_valid),
+            trig_sync.i.eq(self.frame_req.pulse),
+        ]
+
+        add_ila(platform, trace_length=2048, domain="cmv12k_hword", after_trigger=2048-512)
+        probe(m, sensor_rx.phy.output_valid, name="output_valid")
+        for lane in range(32):
+           probe(m, sensor_rx.phy.output[lane], name=f"lane_{lane:02d}")
+        probe(m, sensor_rx.phy.output[-1], name="lane_ctrl")
+        trigger(m, stats.frame_trigger)
+
+        return m
+
+    @driver_method
+    def train(self):
+        self.sensor_rx.trainer.train(self.sensor_spi)
+
+    @driver_method
+    def configure(self):
+        regs = {
+            # internal exposure mode, default value
+             70: 0,
+             71: 1536,
+             72: 0,
+
+             80: 1, # one frame per request
+
+             81: 1, # two side readout, 16 outputs per side
+
+            # disable unused LVDS channels
+             90: 0b0101010101010101,
+             91: 0b0101010101010101,
+             92: 0b0101010101010101,
+             93: 0b0101010101010101,
+
+            117: 1, # unity digital gain
+
+            122: 3, # enable test pattern
+
+            # 12 bit additional settings, 16 outputs per side, normal mode
+             82: 1822,
+             83: 5897,
+             84: 257,
+             85: 257,
+             86: 257,
+             87: 1910,
+             88: 1910,
+             98: 39433,
+            107: (81 << 7) | 94, # 250MHz
+            109: 14448,
+            113: 542,
+            114: 200,
+
+            # ADC settings for 12 bit at 250MHz
+            116: (3 << 8) | 167,
+            100: 3,
+        }
+
+        for addr, value in regs.items():
+            self.sensor_spi.write_reg(addr, value)
+
+    @driver_method
+    def capture_pattern(self):
+        print("training link...")
+        self.train()
+
+        print("capturing pattern...")
+        self.configure()
+        self.stats.reset = 1
+        self.ila.reset = 1
+        self.frame_req = 1
+        print(self.stats.__repr__(allow_recursive=True))
+
+        print("downloading pattern...")
+        pattern = list(self.ila.get_values())
+
+        return pattern
+
+if __name__ == "__main__":
+    cli(Top, runs_on=(BetaPlatform, ), possible_socs=(ZynqSocPlatform, ))

--- a/applets/cmv12k/pattern_test.py
+++ b/applets/cmv12k/pattern_test.py
@@ -104,60 +104,13 @@ class Top(Elaboratable):
         return m
 
     @driver_method
-    def train(self):
-        self.sensor_rx.trainer.train(self.sensor_spi)
-
-    @driver_method
-    def configure(self):
-        regs = {
-            # internal exposure mode, default value
-             70: 0,
-             71: 1536,
-             72: 0,
-
-             80: 1, # one frame per request
-
-             81: 1, # two side readout, 16 outputs per side
-
-            # disable unused LVDS channels
-             90: 0b0101010101010101,
-             91: 0b0101010101010101,
-             92: 0b0101010101010101,
-             93: 0b0101010101010101,
-
-            117: 1, # unity digital gain
-
-            122: 3, # enable test pattern
-
-            # 12 bit additional settings, 16 outputs per side, normal mode
-             82: 1822,
-             83: 5897,
-             84: 257,
-             85: 257,
-             86: 257,
-             87: 1910,
-             88: 1910,
-             98: 39433,
-            107: (81 << 7) | 94, # 250MHz
-            109: 14448,
-            113: 542,
-            114: 200,
-
-            # ADC settings for 12 bit at 250MHz
-            116: (3 << 8) | 167,
-            100: 3,
-        }
-
-        for addr, value in regs.items():
-            self.sensor_spi.write_reg(addr, value)
-
-    @driver_method
     def capture_pattern(self):
         print("training link...")
-        self.train()
+        self.sensor_rx.configure_sensor_defaults(self.sensor_spi)
+        self.sensor_rx.trainer.train(self.sensor_spi)
 
         print("capturing pattern...")
-        self.configure()
+        self.sensor_spi.enable_test_pattern(True)
         self.stats.reset = 1
         self.ila.reset = 1
         self.frame_req = 1

--- a/applets/cmv12k/train_test.py
+++ b/applets/cmv12k/train_test.py
@@ -39,6 +39,7 @@ class Top(Elaboratable):
 
     @driver_method
     def train(self):
+        self.sensor_rx.configure_sensor_defaults(self.sensor_spi)
         self.sensor_rx.trainer.train(self.sensor_spi)
 
 if __name__ == "__main__":

--- a/naps/cores/cmv12k/cmv12k_rx.py
+++ b/naps/cores/cmv12k/cmv12k_rx.py
@@ -1,4 +1,5 @@
 from nmigen import *
+from naps import driver_method
 from .s7_phy import HostTrainer, Cmv12kPhy
 
 __all__ = ["Cmv12kRx"]
@@ -77,3 +78,11 @@ class Cmv12kRx(Elaboratable):
         ]
 
         return m
+
+    @driver_method
+    def configure_sensor_defaults(self, sensor_spi):
+        """configure sensor readout modes and default settings"""
+        sensor_spi.set_readout_configuration(self.num_lanes, self.bits, self.freq, self.mode)
+        sensor_spi.enable_test_pattern(False)
+        sensor_spi.set_number_frames(1)
+        sensor_spi.set_exposure_value(1536)

--- a/naps/cores/cmv12k/cmv12k_spi.py
+++ b/naps/cores/cmv12k/cmv12k_spi.py
@@ -7,7 +7,13 @@ __all__ = ["Cmv12kSpi"]
 class Cmv12kSpi(Elaboratable):
     def __init__(self, sensor_spi):
         self.sensor_spi = sensor_spi
+
+        # runtime variables
         self.spiobj = None
+        self.num_lanes = None
+        self.bits = None
+        self.freq = None
+        self.mode = None
 
     def elaborate(self, platform):
         m = Module()
@@ -17,13 +23,80 @@ class Cmv12kSpi(Elaboratable):
         return m
 
     @driver_method
+    def set_readout_configuration(self, num_lanes, bits, freq, mode):
+        # see cmv12k_rx.py for definitions
+        assert num_lanes == 32
+        assert bits == 12
+        assert freq == 250e6
+        assert mode == "normal"
+        self.num_lanes = num_lanes
+        self.bits = bits
+        self.freq = freq
+        self.mode = mode
+
+        regs = {
+             81: 1, # two side readout, 16 outputs per side
+            118: 0, # 12 bit readout
+
+            # disable unused LVDS channels
+             90: 0b0101010101010101,
+             91: 0b0101010101010101,
+             92: 0b0101010101010101,
+             93: 0b0101010101010101,
+
+            117: 1, # unity digital gain at 12 bits
+
+            # 12 bit additional settings, 16 outputs per side, normal mode
+             82: 1822,
+             83: 5897,
+             84: 257,
+             85: 257,
+             86: 257,
+             87: 1910,
+             88: 1910,
+             98: 39433,
+            107: (81 << 7) | 94, # 250MHz
+            109: 14448,
+            113: 542,
+            114: 200,
+
+            # ADC settings for 12 bit at 250MHz
+            116: (3 << 8) | 167,
+            100: 3,
+
+            # fixed value registers
+             99: 34956,
+            102: 8302,
+            108: 12381,
+            110: 12368,
+            112: 277,
+            124: 15,
+        }
+
+        self.write_regs(regs.items())
+
+
+    @driver_method
     def set_train_pattern(self, pattern):
         self.write_reg(89, pattern)
 
     @driver_method
-    def set_bit_mode(self, mode):
-        assert mode == 12
-        self.write_reg(118, 0) # for 12 bits
+    def enable_test_pattern(self, enabled):
+        self.write_reg(122, 3 if enabled else 0)
+
+    @driver_method
+    def set_number_frames(self, number):
+        """number of frames to be captured in internal exposure mode"""
+        assert number > 0
+        self.write_reg(80, number)
+
+    @driver_method
+    def set_exposure_value(self, value):
+        """exposure value according to datasheet equation. if None, external exposure mode is enabled"""
+        self.write_reg(70, 1 if value is None else 0) # external exposure mode
+        if value is not None:
+            self.write_regs([(71, value & 0xFFFF), (72, value >> 16)]) # 24 bits
+
 
     @driver_method
     def write_reg(self, reg, value):

--- a/naps/cores/cmv12k/s7_phy.py
+++ b/naps/cores/cmv12k/s7_phy.py
@@ -70,7 +70,9 @@ class HostTrainer(Elaboratable):
 
     @driver_method
     def train(self, sensor_spi):
-        self.configure_sensor(sensor_spi)
+        # set default train pattern
+        sensor_spi.set_train_pattern(0b101010_010101)
+        self.lane_pattern = 0b101010_010101
 
         self.set_clock_delay(16) # set clock delay to middle position
 
@@ -111,14 +113,6 @@ class HostTrainer(Elaboratable):
         while delay > 0:
             self.ctrl_lane_delay_inc = 2 # increment clock delay
             delay -= 1
-
-    @driver_method
-    def configure_sensor(self, sensor_spi):
-        # set default train pattern
-        sensor_spi.set_train_pattern(0b101010_010101)
-        self.lane_pattern = 0b101010_010101
-        # switch (only) sensor sequencer to 12 bit mode
-        sensor_spi.set_bit_mode(12)
 
     @driver_method
     def initial_alignment(self):

--- a/naps/cores/debug/ila.py
+++ b/naps/cores/debug/ila.py
@@ -70,6 +70,9 @@ class Ila(Elaboratable):
         if hasattr(platform, "ila_error"):
             raise platform.ila_error
 
+        after_trigger = Signal.like(self.after_trigger)
+        m.submodules += FFSynchronizer(self.after_trigger, after_trigger)
+
         assert hasattr(platform, "trigger"), "No trigger in Design"
         trigger = Signal()
         m.submodules += FFSynchronizer(platform.trigger, trigger)
@@ -107,7 +110,7 @@ class Ila(Elaboratable):
                 with m.If(trigger & (since_reset > self.trace_length - 1)):
                     m.d.sync += self.trigger_since.eq(1)
             with m.Else():
-                with m.If(self.trigger_since < (self.after_trigger - 1)):
+                with m.If(self.trigger_since < (after_trigger - 1)):
                     m.d.sync += self.trigger_since.eq(self.trigger_since + 1)
                 with m.Else():
                     m.d.sync += self.running.eq(0)

--- a/naps/cores/peripherals/soc_memory.py
+++ b/naps/cores/peripherals/soc_memory.py
@@ -66,7 +66,8 @@ class SocMemory(Elaboratable):
             return m
 
         memorymap = MemoryMap()
-        memorymap.allocate("memory", writable=True, bits=self.depth * memorymap.bus_word_width)
+        assert memorymap.bus_word_width == 32
+        memorymap.allocate("memory", writable=True, bits=self.depth * self.split_stages * memorymap.bus_word_width)
         m.submodules += Peripheral(
             self.handle_read,
             self.handle_write,

--- a/naps/cores/peripherals/soc_memory.py
+++ b/naps/cores/peripherals/soc_memory.py
@@ -136,16 +136,16 @@ class SocMemory(Elaboratable):
 
     @driver_method
     def __getitem__(self, item):
-        base_address = item * self.split_stages
+        base_address = self.memory.address - self._memory_accessor.base + item * self.split_stages
         value = 0
         for i in range(self.split_stages):
-            read = self._memory_accessor.read(self.memory.address + base_address + i)
+            read = self._memory_accessor.read(base_address + i)
             value |= read << (32 * i)
         return value
 
     @driver_method
     def __setitem__(self, item, value):
-        base_address = item * self.split_stages
+        base_address = self.memory.address - self._memory_accessor.base + item * self.split_stages
         for i in range(self.split_stages):
             write = (value >> (32 * i)) & 0xFFFFFFFF
-            self._memory_accessor.write(self.memory.address + base_address + i, write)
+            self._memory_accessor.write(base_address + i, write)

--- a/naps/cores/peripherals/soc_memory_test.py
+++ b/naps/cores/peripherals/soc_memory_test.py
@@ -14,8 +14,9 @@ class SocMemoryTest(unittest.TestCase):
             axi = platform.axi_lite_master
             memorymap = platform.memorymap
             for addr in range(128):
-                yield from axil_write(axi, addr + 0x40000000, addr)
-                self.assertEqual(addr, (yield from axil_read(axi, addr + 0x40000000)))
+                yield from axil_write(axi, 4*addr + 0x40000000, addr)
+            for addr in range(128):
+                self.assertEqual(addr, (yield from axil_read(axi, 4*addr + 0x40000000)))
 
         platform.sim(dut, (testbench, "axi_lite"))
 


### PR DESCRIPTION
This PR adds an applet which programs the CMV12K sensor to produce its test pattern, then receives and validates it. The received pattern will be used to develop and simulate the logic which writes sensor data to DRAM.

To do:
- [x] remove/justify/improve SocMemory hacks
- [x] validate and dump test pattern
- [x] improve handling of sensor register configuration